### PR TITLE
Fix get_current_onair_talk to get today's talks.

### DIFF
--- a/cndctl/Dreamkast.py
+++ b/cndctl/Dreamkast.py
@@ -10,6 +10,7 @@ import datetime
 import jwt
 
 from .cli import Cli
+from zoneinfo import ZoneInfo
 
 class Dreamkast:
     
@@ -134,6 +135,9 @@ class Dreamkast:
         conference_day_ids = self.get_conference_day_ids()
         for day_id in conference_day_ids:
             if day_id['internal'] == True:
+                continue
+
+            if day_id['date'] != datetime.datetime.now(ZoneInfo("Asia/Tokyo")).strftime('%Y-%m-%d'):
                 continue
 
             talks = self.get_talks(day_id['id'])


### PR DESCRIPTION
複数日付のイベントの際に初日のトークしか見ていなかったので、本日日付のトークを取るように修正。