### PR TITLE
Fix dreamkast

### DIFF
--- a/cndctl/Dreamkast.py
+++ b/cndctl/Dreamkast.py
@@ -225,6 +225,10 @@ class Dreamkast:
         tracks = self.get_track()
         track_id = self.get_track_id(track_name, tracks)
         current_onair_talk_id = self.get_current_onair_talk(track_id)["id"]
+        # 現在OnAirなTalkが存在しない
+        if current_onair_talk_id == 0:
+            logging.error("There is no on-air talk. Please make a talk on-air and then execute it.")
+            sys.exit()
 
         sorted_talks = sorted(talks, key=lambda x: x["start_at"])
         for i, talk in enumerate(sorted_talks):
@@ -232,6 +236,9 @@ class Dreamkast:
                 if len(sorted_talks) != i + 1:
                     # 最後のtalk以外の場合、オンエア切り替えを実施.
                     self.onair(sorted_talks[i + 1]["id"])
+        
+        # OnAirなTalkは存在するが対象の event_date と track に存在しない
+        logging.warning("There is no OnAir Talk for the specified `event_date` and `track` combination. The currently OnAir Talks are: %s", self.get_talk(current_onair_talk_id))
 
     def onair(self, dk_talk_id):
         cli = Cli()

--- a/cndctl/Dreamkast.py
+++ b/cndctl/Dreamkast.py
@@ -209,7 +209,13 @@ class Dreamkast:
             )
 
     def onair_next(self, track_name: str, event_date: str):
+        if event_date == "":
+            event_date = datetime.datetime.now().strftime('%Y-%m-%d')
+        
         talks = self.get_talks_in_track_and_event_date(track_name, event_date)
+        if not talks:
+            logging.error("Could not get Talks. Request config: DATE='%s', TRACK='%s'", event_date, track_name)
+            sys.exit()
 
         for talk in talks:
             talk["start_at"] = datetime.datetime.fromisoformat(

--- a/cndctl/Dreamkast.py
+++ b/cndctl/Dreamkast.py
@@ -208,6 +208,15 @@ class Dreamkast:
                 f"{onair_status} {talk['id']} [{talk['start_at']} - {talk['end_at']}]({talk['duration']}): {talk['title']}"
             )
 
+    def onair_next_cmd(self, track_name: str, event_date: str):
+        if event_date == "":
+            event_date = datetime.datetime.now().strftime('%Y-%m-%d')
+
+        if self.onair_next(track_name, event_date):
+            sys.exit(0)
+        else:
+            sys.exit(1)
+
     def onair_next(self, track_name: str, event_date: str):
         if event_date == "":
             event_date = datetime.datetime.now().strftime('%Y-%m-%d')
@@ -234,7 +243,7 @@ class Dreamkast:
         # 現在OnAirなTalkが存在しない
         if current_onair_talk_id == 0:
             logging.error("There is no on-air talk. Please make a talk on-air and then execute it.")
-            sys.exit()
+            return False
 
         sorted_talks = sorted(talks, key=lambda x: x["start_at"])
         for i, talk in enumerate(sorted_talks):
@@ -242,9 +251,11 @@ class Dreamkast:
                 if len(sorted_talks) != i + 1:
                     # 最後のtalk以外の場合、オンエア切り替えを実施.
                     self.onair(sorted_talks[i + 1]["id"])
-        
+                    return True
+
         # OnAirなTalkは存在するが対象の event_date と track に存在しない
         logging.warning("There is no OnAir Talk for the specified `event_date` and `track` combination. The currently OnAir Talks are: %s", self.get_talk(current_onair_talk_id))
+        return False
 
     def onair(self, dk_talk_id):
         cli = Cli()

--- a/cndctl/Operator.py
+++ b/cndctl/Operator.py
@@ -1,5 +1,6 @@
 import datetime
 import sys
+import pprint
 
 from .Dreamkast import Dreamkast
 from .Scene import Scene
@@ -26,3 +27,16 @@ class Operator:
         
         print("\n")
         self.loop.run_until_complete(self.scene.next())
+    
+    def now_cmd(self, track_name: str, event_date: str):
+        if event_date == "":
+            event_date = datetime.datetime.now().strftime('%Y-%m-%d')
+
+        tracks = self.dk.get_track()
+        for track in tracks:
+            if track['name'] == track_name:
+                track_id = track['id']
+        current_talk = self.dk.get_current_onair_talk(track_id)
+        current_scene = self.loop.run_until_complete(self.scene.current())
+        print(f"talk  : {current_talk['id']}_{current_talk['title']}")
+        print(f"scene : {current_scene}")

--- a/cndctl/Operator.py
+++ b/cndctl/Operator.py
@@ -1,0 +1,28 @@
+import datetime
+import sys
+
+from .Dreamkast import Dreamkast
+from .Scene import Scene
+
+class Operator:
+    def __init__(self, dreamkast, loop, scene):
+        self.dk = dreamkast
+        self.loop = loop
+        self.scene = scene
+
+    def next_cmd(self, track_name: str, event_date: str):
+        if event_date == "":
+            event_date = datetime.datetime.now().strftime('%Y-%m-%d')
+
+        print("||| CURRENT TRACK TALKS |||")
+        self.dk.get_track_talks_cmd(track_name, event_date)
+        
+        print("\n")
+        if not self.dk.onair_next(track_name, event_date):
+            sys.exit(1)
+
+        print("\n||| CURRENT SWICHER SCENES |||")
+        self.loop.run_until_complete(self.scene.get())
+        
+        print("\n")
+        self.loop.run_until_complete(self.scene.next())

--- a/cndctl/Scene.py
+++ b/cndctl/Scene.py
@@ -47,7 +47,7 @@ class Scene:
             if scene["sceneName"] == ret.responseData["currentProgramSceneName"]
         ][0]
         current_program_scene_name = ret.responseData["currentProgramSceneName"]
-        print(current_program_scene_name)
+        print(f"current scene | {current_program_scene_name}")
         logger.info(
             "current: [%s]%s", current_program_scene_index, current_program_scene_name
         )
@@ -58,6 +58,7 @@ class Scene:
         else:
             logger.info("nextScene: [%s]%s", next_scene_index, scenes[next_scene_index])
 
+        print(f"next    scene | {scenes[next_scene_index]['sceneName']}")
         if not self.cli.accept_continue(
             f"Change scene to '{scenes[next_scene_index]['sceneName']}'"
         ):

--- a/cndctl/Scene.py
+++ b/cndctl/Scene.py
@@ -26,7 +26,7 @@ class Scene:
         current_preview_scene = ret.responseData["currentPreviewSceneName"]
         logger.info(ret)
 
-        print("PG PR NAME")
+        print("PR PG NAME")
         for scene in reversed(scenes):
             logger.info("scene[%s]: %s", scene["sceneIndex"], scene["sceneName"])
             current_program = " "
@@ -36,7 +36,7 @@ class Scene:
 
             if scene["sceneName"] == current_preview_scene:
                 current_preview = "*"
-            print(f'{current_program}  {current_preview}  {scene["sceneName"]}')
+            print(f'{current_preview}  {current_program}  {scene["sceneName"]}')
 
     async def current(self):
         request = simpleobsws.Request("GetCurrentProgramScene")
@@ -113,28 +113,6 @@ class Scene:
         if not ret.ok():
             logger.error("Request error. Request:%s Response:%s", request, ret)
             sys.exit()
-
-        if next_scene_index == 0:
-            logger.info("no more next scene to preview.")
-        else:
-            next_scene_index -= 1
-            logger.info(
-                "nextScene to preview: [%s]%s",
-                next_scene_index,
-                scenes[next_scene_index],
-            )
-
-        request = simpleobsws.Request(
-            "SetCurrentPreviewScene",
-            {"sceneName": scenes[next_scene_index]["sceneName"]},
-        )
-
-        ret = await self.ws.call(request)
-        if not ret.ok():
-            logger.error("Request error. Request:%s Response:%s", request, ret)
-            sys.exit()
-
-        # logger.info("scene changed: {}".format(sceneName))
 
     # cndctl scene set {sceneName}
     async def change(self, sceneName):

--- a/cndctl/Scene.py
+++ b/cndctl/Scene.py
@@ -22,11 +22,31 @@ class Scene:
             logger.error("Request error. Request:%s Response:%s", request, ret)
             sys.exit()
         scenes = ret.responseData["scenes"]
+        current_program_scene = ret.responseData["currentProgramSceneName"]
+        current_preview_scene = ret.responseData["currentPreviewSceneName"]
         logger.info(ret)
 
+        print("PG PR NAME")
         for scene in reversed(scenes):
             logger.info("scene[%s]: %s", scene["sceneIndex"], scene["sceneName"])
-            print(scene["sceneName"])
+            current_program = " "
+            current_preview = " "
+            if scene["sceneName"] == current_program_scene:
+                current_program = "*"
+
+            if scene["sceneName"] == current_preview_scene:
+                current_preview = "*"
+            print(f'{current_program}  {current_preview}  {scene["sceneName"]}')
+
+    async def current(self):
+        request = simpleobsws.Request("GetCurrentProgramScene")
+
+        ret = await self.ws.call(request)
+        if not ret.ok():
+            logger.error("Request error. Request:%s Response:%s", request, ret)
+            sys.exit()
+
+        return ret.responseData['currentProgramSceneName']
 
     # cndctl scene next
     async def next(self):

--- a/cndctl/cndctl.py
+++ b/cndctl/cndctl.py
@@ -2,7 +2,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
-    level=logging.WARNING, format="%(asctime)s [%(levelname)s] [%(name)s] %(message)s"
+    level=logging.WARNING, format="%(asctime)s [%(levelname)s] %(message)s"
 )
 
 import argparse
@@ -19,6 +19,7 @@ from .Nextcloud import Nextcloud
 from .Scene import Scene
 from .Source import Source
 from .Switcher import Switcher
+from .Operator import Operator
 
 parser = argparse.ArgumentParser(description="obs remote controll cli tool")
 parser.add_argument("object")
@@ -201,7 +202,7 @@ def run():
             if not EVENT_TRACK:
                 print("No enough options: --track or --event-date")
             elif not EVENT_DATE:
-                dreamkast.onair_next(EVENT_TRACK, "")
+                dreamkast.onair_next_cmd(EVENT_TRACK, "")
             dreamkast.onair_next(EVENT_TRACK, EVENT_DATE)
         elif args.operator == "track_talks":
             dreamkast.get_track_talks_cmd(EVENT_TRACK, EVENT_DATE)
@@ -278,6 +279,17 @@ def run():
     elif args.object == "switcher":
         if args.operator == "build":
             loop.run_until_complete(switcher.build(dreamkast, ws))
+
+    # operator
+    op = Operator(dreamkast, loop, scene)
+
+    if args.object == "op":
+        if args.operator == "next":
+            if not EVENT_TRACK:
+                print("No enough options: --track")
+            elif not EVENT_DATE:
+                op.next_cmd()(EVENT_TRACK, "")
+            op.next_cmd(EVENT_TRACK, EVENT_DATE)
 
     else:
         print(f"undefined command: {args}")

--- a/cndctl/cndctl.py
+++ b/cndctl/cndctl.py
@@ -46,6 +46,7 @@ args = parser.parse_args()
 OBS_HOST = ""
 OBS_PORT = ""
 OBS_PASS = ""
+JSON_FILE_PATH =""
 DK_URL = ""
 DK_CLIENT_ID = ""
 DK_CLIENT_SECRETS = ""
@@ -78,9 +79,14 @@ if "EVENT_ABBR" in os.environ:
     EVENT_ABBR = os.environ["EVENT_ABBR"]
 
 # json
+if "CNDCTL_CURRENT_JSON_PATH" in os.environ:
+    JSON_FILE_PATH = os.environ["CNDCTL_CURRENT_JSON_PATH"]
 
 if args.secret:
-    with open(args.secret, encoding="utf-8") as f:
+    JSON_FILE_PATH = args.secret
+
+if JSON_FILE_PATH:
+    with open(JSON_FILE_PATH, encoding="utf-8") as f:
         secret = json.loads(f.read())
 
     if "obs" in secret:

--- a/cndctl/cndctl.py
+++ b/cndctl/cndctl.py
@@ -249,13 +249,16 @@ def run():
     if args.object == "scene":
         if args.operator == "get":
             loop.run_until_complete(scene.get())
+            sys.exit()
         elif args.operator == "change":
             if not args.sceneName:
                 logger.error("No enough options: --sceneName")
                 sys.exit()
             loop.run_until_complete(scene.change(args.sceneName))
+            sys.exit()
         elif args.operator == "next":
             loop.run_until_complete(scene.next())
+            sys.exit()
 
     # source
     elif args.object == "source":
@@ -264,6 +267,7 @@ def run():
                 logger.error("No enough options: --sceneName")
                 sys.exit()
             loop.run_until_complete(source.get(args.sceneName))
+            sys.exit()
 
     # mediasource
     elif args.object == "mediasource":
@@ -274,11 +278,13 @@ def run():
                 logger.error("No enough options: --sourceName")
                 sys.exit()
             loop.run_until_complete(mediasource.time(args.sourceName))
+            sys.exit()
 
     # switcher
     elif args.object == "switcher":
         if args.operator == "build":
             loop.run_until_complete(switcher.build(dreamkast, ws))
+            sys.exit()
 
     # operator
     op = Operator(dreamkast, loop, scene)
@@ -289,7 +295,19 @@ def run():
                 print("No enough options: --track")
             elif not EVENT_DATE:
                 op.next_cmd()(EVENT_TRACK, "")
+                sys.exit()
             op.next_cmd(EVENT_TRACK, EVENT_DATE)
+            sys.exit()
+        if args.operator == "now":
+            if not EVENT_TRACK:
+                print("No enough options: --track")
+            elif not EVENT_DATE:
+                op.now_cmd()(EVENT_TRACK, "")
+                sys.exit()
+            op.now_cmd(EVENT_TRACK, EVENT_DATE)
+            sys.exit()
+            
 
     else:
         print(f"undefined command: {args}")
+        sys.exit(1)

--- a/cndctl/cndctl.py
+++ b/cndctl/cndctl.py
@@ -192,9 +192,10 @@ def run():
                 sys.exit()
             dreamkast.onair(DK_TALK_ID)
         elif args.operator == "onair_next":
-            if not EVENT_TRACK or not EVENT_DATE:
+            if not EVENT_TRACK:
                 print("No enough options: --track or --event-date")
-                sys.exit()
+            elif not EVENT_DATE:
+                dreamkast.onair_next(EVENT_TRACK, "")
             dreamkast.onair_next(EVENT_TRACK, EVENT_DATE)
         elif args.operator == "track_talks":
             dreamkast.get_track_talks_cmd(EVENT_TRACK, EVENT_DATE)


### PR DESCRIPTION
やったこと

### fix
- `dk onair_next` コマンドにて `current_onair_talk_id` が存在しなかった場合の挙動を修正
- `dk onair_next` コマンドにて`--event-date`が指定されなかった場合にコンピュータの現在日時を利用する
- `scene next` コマンドにて`current_preview_scene`が2つ先に移動する問題を修正

### feature
- `CNDCTL_CURRENT_JSON` 変数にJSONのパスを指定することで `--secret`を省略できるようにした
- `op next` コマンドを実装
- `op now` コマンドを実装
- `scene get` コマンドにて現在の`current_program_scene`と`current_preview_scene`を表示するようにした